### PR TITLE
Add README with container build instructions and upgrade Node

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,9 @@
 			"version": "17",
 			"installMaven": "true"
 		},
-		"ghcr.io/devcontainers/features/node:1": {
-		},
+                "ghcr.io/devcontainers/features/node:1": {
+                        "version": "22.12.0"
+                },
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 
 	},
@@ -23,7 +24,7 @@
 	// "postCreateCommand": "java -version",
 	"postCreateCommand": { 
 		"db": "bash -i -c 'sudo apt update && sudo apt install -y mariadb-server && /workspaces/scavenger/builddb.sh'",
-		"node": "bash -i -c 'nvm install node'",
+                "node": "bash -i -c 'nvm install 22.12.0 && nvm use 22.12.0 && cd src/main/frontend && npm install'",
 		"mavendeps": "mvn dependency:resolve"
 	},
 	"postAttachCommand": "sudo /etc/init.d/mariadb start",

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Scavenger
+
+Scavenger is a Spring Boot application used to run a scavenger hunt for the Tech Club. The project pairs a Java backend with a Node/JS front end and persists data in a MariaDB database. The front end is built with Vite 7, which requires Node.js 22.12.0 or newer; the development container installs this runtime automatically.
+
+## Build the application
+
+The Maven wrapper downloads the required Java and Node tooling and builds both the backend and front end:
+
+```
+./mvnw clean package
+```
+
+## Build the Docker image
+
+After packaging, extract the layered jar into `target/dependency` and build the container:
+
+```
+mkdir -p target/dependency
+(cd target/dependency; jar -xf ../*.jar)
+docker build -t scavenger .
+```
+
+Run the image with:
+
+```
+docker run -p 8080:8080 scavenger
+```
+
+The repository also includes a `docker-compose.yml` to run the image together with a MariaDB service.
+
+## Development helpers
+
+- `runserver.sh` – start the Spring Boot application for development
+- `rundev.sh` – run the front-end dev server
+


### PR DESCRIPTION
## Summary
- Add project README detailing application purpose
- Include instructions for building Docker image and running in development
- Install frontend dependencies during devcontainer setup with Node.js 22.12.0

## Testing
- `npm --prefix src/main/frontend install`
- `bash ./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a62b4dcbcc832988e8288a4e2a2165